### PR TITLE
Avoid crashing on empty files

### DIFF
--- a/SnakeTail/MainForm.cs
+++ b/SnakeTail/MainForm.cs
@@ -105,6 +105,11 @@ namespace SnakeTail
 
         public void SetStatusBar(string text, int progressValue, int progressMax)
         {
+            if(progressValue < _statusProgressBar.Minimum)
+            {
+                // Make sure progressValue is withing range even for empty files
+                progressValue = _statusProgressBar.Minimum;
+            }
             _statusProgressBar.Maximum = progressMax;
             _statusProgressBar.Value = progressValue;
             if (progressMax == 0 && progressValue == 0)


### PR DESCRIPTION
When loading an empty the progressbar goes bananas and the application crashes.
![image](https://cloud.githubusercontent.com/assets/5158396/10404405/cd0a5370-6ed2-11e5-925f-d30d03ab5d1d.png)

This is because when the filestream length is 0, the calculated position for the progressbar gets double.NaN and when casted to an int it gets out of the progressbar range.

This fix avoids the crash by moving values below the allowed range to the first valid value of the progressbar.
