### PR TITLE
Add bin and obj to .gitignore 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+SnakeTail/bin/
+SnakeTail/obj


### PR DESCRIPTION
Add bin and obj to .gitignore to avoid adding files that should not be in the version control

Standard git practices to get a smooth development experience.