### PR TITLE
Add option to display line numbers

### DIFF
--- a/SnakeTail/EventLogForm.cs
+++ b/SnakeTail/EventLogForm.cs
@@ -38,6 +38,7 @@ namespace SnakeTail
         bool _displayTabIcon;
         bool _topItemIndexHack = false;
         bool _formMinimizedAtBottom = false;
+        bool _displayLineNumbers = false;
 
         public EventLogForm()
         {
@@ -89,6 +90,7 @@ namespace SnakeTail
             }
             tailConfig.ColumnFilterActive = _filterActive;
             tailConfig.DisplayTabIcon = _displayTabIcon;
+            tailConfig.DisplayLineNumbers = _displayLineNumbers;
         }
 
         public void LoadConfig(TailFileConfig tailConfig, string configPath)
@@ -161,6 +163,7 @@ namespace SnakeTail
 
             _filterActive = tailConfig.ColumnFilterActive;
             _displayTabIcon = tailConfig.DisplayTabIcon;
+            _displayLineNumbers = tailConfig.DisplayLineNumbers;
 
             if (Visible)
             {

--- a/SnakeTail/TailConfig.cs
+++ b/SnakeTail/TailConfig.cs
@@ -191,6 +191,7 @@ namespace SnakeTail
         public string ServiceName { get; set; }
         public string IconFile { get; set; }
         public bool DisplayTabIcon { get; set; }
+        public bool DisplayLineNumbers { get; set; }
         public bool ColumnFilterActive { get; set; }
         [XmlArray("ColumnFilters")]
         [XmlArrayItem("Filters")]

--- a/SnakeTail/TailConfigApplyAllForm.Designer.cs
+++ b/SnakeTail/TailConfigApplyAllForm.Designer.cs
@@ -49,6 +49,7 @@ namespace SnakeTail
             this._buttonOk = new System.Windows.Forms.Button();
             this._buttonCancel = new System.Windows.Forms.Button();
             this._checkboxTools = new System.Windows.Forms.CheckBox();
+            this._checkBoxLineNumbers = new System.Windows.Forms.CheckBox();
             this.SuspendLayout();
             // 
             // _checkBoxColors
@@ -74,7 +75,7 @@ namespace SnakeTail
             // _checkboxKeywords
             // 
             this._checkboxKeywords.AutoSize = true;
-            this._checkboxKeywords.Location = new System.Drawing.Point(12, 58);
+            this._checkboxKeywords.Location = new System.Drawing.Point(12, 81);
             this._checkboxKeywords.Name = "_checkboxKeywords";
             this._checkboxKeywords.Size = new System.Drawing.Size(111, 17);
             this._checkboxKeywords.TabIndex = 2;
@@ -85,7 +86,7 @@ namespace SnakeTail
             // 
             this._buttonOk.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this._buttonOk.DialogResult = System.Windows.Forms.DialogResult.OK;
-            this._buttonOk.Location = new System.Drawing.Point(75, 107);
+            this._buttonOk.Location = new System.Drawing.Point(75, 136);
             this._buttonOk.Name = "_buttonOk";
             this._buttonOk.Size = new System.Drawing.Size(75, 23);
             this._buttonOk.TabIndex = 4;
@@ -96,7 +97,7 @@ namespace SnakeTail
             // 
             this._buttonCancel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this._buttonCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this._buttonCancel.Location = new System.Drawing.Point(165, 107);
+            this._buttonCancel.Location = new System.Drawing.Point(165, 136);
             this._buttonCancel.Name = "_buttonCancel";
             this._buttonCancel.Size = new System.Drawing.Size(75, 23);
             this._buttonCancel.TabIndex = 5;
@@ -106,12 +107,22 @@ namespace SnakeTail
             // _checkboxTools
             // 
             this._checkboxTools.AutoSize = true;
-            this._checkboxTools.Location = new System.Drawing.Point(12, 81);
+            this._checkboxTools.Location = new System.Drawing.Point(12, 104);
             this._checkboxTools.Name = "_checkboxTools";
             this._checkboxTools.Size = new System.Drawing.Size(93, 17);
             this._checkboxTools.TabIndex = 3;
             this._checkboxTools.Text = "External Tools";
             this._checkboxTools.UseVisualStyleBackColor = true;
+            // 
+            // _checkBoxLineNumbers
+            // 
+            this._checkBoxLineNumbers.AutoSize = true;
+            this._checkBoxLineNumbers.Location = new System.Drawing.Point(12, 58);
+            this._checkBoxLineNumbers.Name = "_checkBoxLineNumbers";
+            this._checkBoxLineNumbers.Size = new System.Drawing.Size(128, 17);
+            this._checkBoxLineNumbers.TabIndex = 6;
+            this._checkBoxLineNumbers.Text = "Display Line Numbers";
+            this._checkBoxLineNumbers.UseVisualStyleBackColor = true;
             // 
             // TailConfigApplyAllForm
             // 
@@ -119,7 +130,8 @@ namespace SnakeTail
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.CancelButton = this._buttonCancel;
-            this.ClientSize = new System.Drawing.Size(252, 142);
+            this.ClientSize = new System.Drawing.Size(252, 171);
+            this.Controls.Add(this._checkBoxLineNumbers);
             this.Controls.Add(this._checkboxTools);
             this.Controls.Add(this._buttonCancel);
             this.Controls.Add(this._buttonOk);
@@ -147,5 +159,6 @@ namespace SnakeTail
         private System.Windows.Forms.Button _buttonOk;
         private System.Windows.Forms.Button _buttonCancel;
         public System.Windows.Forms.CheckBox _checkboxTools;
+        public System.Windows.Forms.CheckBox _checkBoxLineNumbers;
     }
 }

--- a/SnakeTail/TailConfigForm.Designer.cs
+++ b/SnakeTail/TailConfigForm.Designer.cs
@@ -96,6 +96,7 @@ namespace SnakeTail
             this._cancelBtn = new System.Windows.Forms.Button();
             this._applyAllBtn = new System.Windows.Forms.Button();
             this._saveDefaultBtn = new System.Windows.Forms.Button();
+            this._displayLineNumbersChk = new System.Windows.Forms.CheckBox();
             label2 = new System.Windows.Forms.Label();
             label1 = new System.Windows.Forms.Label();
             label3 = new System.Windows.Forms.Label();
@@ -254,6 +255,7 @@ namespace SnakeTail
             // 
             // _tabPageView
             // 
+            this._tabPageView.Controls.Add(this._displayLineNumbersChk);
             this._tabPageView.Controls.Add(this._bookmarkBackColorBtn);
             this._tabPageView.Controls.Add(this._bookmarkTextColorBtn);
             this._tabPageView.Controls.Add(this._displayIconChk);
@@ -652,6 +654,16 @@ namespace SnakeTail
             this._saveDefaultBtn.UseVisualStyleBackColor = true;
             this._saveDefaultBtn.Click += new System.EventHandler(this._saveDefaultBtn_Click);
             // 
+            // _displayLineNumbersChk
+            // 
+            this._displayLineNumbersChk.AutoSize = true;
+            this._displayLineNumbersChk.Location = new System.Drawing.Point(11, 161);
+            this._displayLineNumbersChk.Name = "_displayLineNumbersChk";
+            this._displayLineNumbersChk.Size = new System.Drawing.Size(122, 17);
+            this._displayLineNumbersChk.TabIndex = 17;
+            this._displayLineNumbersChk.Text = "Display line numbers";
+            this._displayLineNumbersChk.UseVisualStyleBackColor = true;
+            // 
             // TailConfigForm
             // 
             this.AcceptButton = this._acceptBtn;
@@ -723,8 +735,6 @@ namespace SnakeTail
         private System.Windows.Forms.Button _bookmarkTextColorBtn;
         private System.Windows.Forms.Button _bookmarkBackColorBtn;
         private System.Windows.Forms.Button _saveDefaultBtn;
-
-
-
+        private System.Windows.Forms.CheckBox _displayLineNumbersChk;
     }
 }

--- a/SnakeTail/TailConfigForm.cs
+++ b/SnakeTail/TailConfigForm.cs
@@ -63,6 +63,7 @@ namespace SnakeTail
             _windowTitleEdt.Text = TailFileConfig.Title;
             _windowIconEdt.Text = TailFileConfig.IconFile;
             _displayIconChk.Checked = TailFileConfig.DisplayTabIcon;
+            _displayLineNumbersChk.Checked = TailFileConfig.DisplayLineNumbers;
 
             if (_displayFileTab)
             {
@@ -121,6 +122,7 @@ namespace SnakeTail
             TailFileConfig.Title = _windowTitleEdt.Text;
             TailFileConfig.IconFile = _windowIconEdt.Text;
             TailFileConfig.DisplayTabIcon = _displayIconChk.Checked;
+            TailFileConfig.DisplayLineNumbers = _displayLineNumbersChk.Checked;
 
             if (_displayFileTab)
             {

--- a/SnakeTail/TailForm.cs
+++ b/SnakeTail/TailForm.cs
@@ -96,6 +96,7 @@ namespace SnakeTail
         List<TailKeywordConfig> _keywordHighlight;
         int _loghitCounter = -1;
         bool _displayTabIcon = false;
+        bool _displayLineNumbers = false;
         List<ExternalToolConfig> _externalTools;
         Color _bookmarkTextColor = Color.Yellow;    // Default bookmark text color
         Color _bookmarkBackColor = Color.DarkGreen; // Default bookmark background color
@@ -285,6 +286,7 @@ namespace SnakeTail
             UpdateFormTitle(true);
 
             _displayTabIcon = tailConfig.DisplayTabIcon;
+            _displayLineNumbers = tailConfig.DisplayLineNumbers;
 
             if (!string.IsNullOrEmpty(tailConfig.IconFile))
             {
@@ -547,6 +549,7 @@ namespace SnakeTail
                 tailConfig.ServiceName = "";
 
             tailConfig.DisplayTabIcon = _displayTabIcon;
+            tailConfig.DisplayLineNumbers = _displayLineNumbers;
         }
 
         public void CopySelectionToClipboard()
@@ -1547,6 +1550,8 @@ namespace SnakeTail
                                     }
                                     if (configFormApply._checkBoxFont.Checked)
                                         configFileOther.FontInvariant = configFile.FontInvariant;
+                                    if (configFormApply._checkBoxLineNumbers.Checked)
+                                        configFileOther.DisplayLineNumbers = configFile.DisplayLineNumbers;
                                     if (configFormApply._checkboxKeywords.Checked)
                                         configFileOther.KeywordHighlight = configFile.KeywordHighlight;
                                     if (configFormApply._checkboxTools.Checked)

--- a/SnakeTail/TailForm.cs
+++ b/SnakeTail/TailForm.cs
@@ -103,6 +103,11 @@ namespace SnakeTail
         List<int> _bookmarks = new List<int>();
         ThreadPoolQueue _threadPoolQueue = null;
 
+        const int MAX_LINE_WIDTH = 1000;
+        const int LINE_NUMBER_WIDTH = 10; // Support maximum Int32 representable number 2^32 (~2 billion)
+        const string LINE_NUMBER_SEPARATOR = ": "; // Divider between line number and line content
+        readonly int MAX_LINE_WIDTH_WITH_LINE_NUMBER = MAX_LINE_WIDTH - (LINE_NUMBER_WIDTH + LINE_NUMBER_SEPARATOR.Length);
+
         public TailForm()
         {
             InitializeComponent();
@@ -943,10 +948,28 @@ namespace SnakeTail
             e.DrawFocusRectangle(e.Bounds);
 
             TextFormatFlags flags = TextFormatFlags.Left | TextFormatFlags.ExpandTabs | TextFormatFlags.SingleLine | TextFormatFlags.NoPrefix;
-            if (e.Item.Text.Length > 1000)
-                TextRenderer.DrawText(e.Graphics, e.Item.Text.Substring(0, 1000), e.Item.ListView.Font, e.Bounds, e.SubItem.ForeColor, flags);
-            else
-                TextRenderer.DrawText(e.Graphics, e.Item.Text, e.Item.ListView.Font, e.Bounds, e.SubItem.ForeColor, flags);
+            // Integer line number (+1 for non-zero index)
+            string text = ConstructLineForRendering(e.Item.Text, e.ItemIndex + 1);
+            TextRenderer.DrawText(e.Graphics, text, e.Item.ListView.Font, e.Bounds, e.SubItem.ForeColor, flags);
+        }
+
+        /// <summary>
+        /// Constructs a single line for drawing purposes
+        /// Optionally allows display of line number prefix
+        /// </summary>
+        /// <param name="rawText">A single line for rendering</param>
+        /// <param name="lineNumber">Line number in monitored file (1-indexed)</param>
+        /// <param name="bDisplayLineNumber">Include line number in text rendering string</param>
+        /// <returns></returns>
+        private string ConstructLineForRendering(string rawText, int lineNumber)
+        {
+            int maxLength = _displayLineNumbers ? MAX_LINE_WIDTH_WITH_LINE_NUMBER : MAX_LINE_WIDTH;
+            string truncText = rawText.Length > maxLength ? rawText.Substring(0, maxLength) : rawText;
+
+            if (_displayLineNumbers)
+                // Left pad 10, coverage of 2^32 potential line numbers (~2 billion for Int32)
+                return string.Format("{0,10:N0}{1}{2}", lineNumber, LINE_NUMBER_SEPARATOR, truncText); 
+            return truncText;
         }
 
         private bool MatchesBookmark(int lineNumber)


### PR DESCRIPTION
Adds a user option to display simple line number prefixes in the tails display window.

Features:
* Ability to turn on/off display of line numbers per-file config.
* Ability to apply line number display setting to all open logs (apply all).
* Ability to set line number display option as a global default preference for newly opened configs.
* When turned on, line numbers draw as a right-aligned prefix to each line with ": " between the line number and line content.
  * NOTE: Right alignment is 10 character width, which supports 2^32 (~2 billion) line numbers supported by 32-bit signed integer, without thousands separators.
* Truncation for lines has been updated such that truncation now takes into account inclusion of the line number & separator to ensure whole line width stays within the pre-existing 1000 character limit.
* Line numbers are 1 indexed based on the index in the list item virtual cache (index + 1).
  * NOTE: This assumes that this absolute index is correct in terms of position in source file and display in the tails window.

Testing:
* Tested with a continuous append log file up to ~3 million lines.
* Tested scrolling to begin/end of tails with
* Tested scrolling to random sampling of positions within log file
* Tested deleting a set of middle lines from log
  * NOTE: Update seemed to work correctly, however the update was slower than simple append updates and fast navigation to distant locations in the log as the entire file was reloaded & lines recalculated (existing functionality).