### PR TITLE
Increasing search performance for case sensitive searches

### DIFF
--- a/SnakeTail/LogFileCache.cs
+++ b/SnakeTail/LogFileCache.cs
@@ -67,10 +67,7 @@ namespace SnakeTail
 
             if (index >= FirstIndex && index < FirstIndex + Items.Count)
             {
-                if (Items[index - FirstIndex] != null)
-                    return Items[index - FirstIndex];
-                else
-                    return null;
+                return Items[index - FirstIndex];
             }
             else
             {

--- a/SnakeTail/MainForm.cs
+++ b/SnakeTail/MainForm.cs
@@ -939,7 +939,6 @@ namespace SnakeTail
 
         private TabPage GetTabPageFromLocation(TabControl tabControl, Point point)
         {
-            TabPage tabPageCurrent = null;
             for (var i = 0; i < tabControl.TabCount; i++)
             {
                 if (!tabControl.GetTabRect(i).Contains(point))

--- a/SnakeTail/TailForm.cs
+++ b/SnakeTail/TailForm.cs
@@ -584,7 +584,7 @@ namespace SnakeTail
             else
             if (matchCase)
             {
-                if (0 <= lineText.IndexOf(searchText))
+                if (lineText.Contains(searchText))
                 {
                     return true;
                 }
@@ -737,6 +737,8 @@ namespace SnakeTail
         {
             // First use the visual cache, when that have failed, then revert to search from the beginning
             // and find the last match
+
+
             for (int i = startIndex; i >= endIndex; --i)
             {
                 if (i % _logFileCache.Items.Count == 0)

--- a/SnakeTail/TailForm.cs
+++ b/SnakeTail/TailForm.cs
@@ -737,8 +737,6 @@ namespace SnakeTail
         {
             // First use the visual cache, when that have failed, then revert to search from the beginning
             // and find the last match
-
-
             for (int i = startIndex; i >= endIndex; --i)
             {
                 if (i % _logFileCache.Items.Count == 0)


### PR DESCRIPTION
This might be one of those micro-optimizations that might not be worth your time.
But I thought it was fun to do, so here are some results:

In a file searching for this case-sensitive text, contains is just a tiny bit faster.
With a file over 1 million records (60MB):

Old (in ms):
2412
2415
2360
2349
2365
2388
2357
2354
2367
2394

New (in ms):
2211
2216
2162
2161
2138
2145
2147
2154


It is obviously a micro-optimization that works for me on my machine, but I found various sources .Contains is faster. Feel free to reject if this doesn't make sense.

In the coming days I will try to find some more constructive improvements in searching, when time allows. :)
